### PR TITLE
docs: open README nav links in new window

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 **[Duke history](https://dev.java/duke/)**
 
-[Documentation](docs/prj-agent.md) | [Changes from Upstream](docs/CHANGES.md) |  [Project Blog](https://www.sipsjava.com/blog/)
+<a href="docs/prj-agent.md" target="_blank">Documentation</a> | <a href="docs/CHANGES.md" target="_blank">Changes from Upstream</a> | <a href="https://www.sipsjava.com/blog/" target="_blank">Project Blog</a>
 
 JVMXRay monitors Java applications in real-time via bytecode injection, detecting vulnerabilities and suspicious activity without code changes. 19 modular sensors track file access, network connections, SQL queries, cryptographic operations, authentication, process execution, and more — generating structured, machine-readable security events with automatic cross-sensor correlation.
 


### PR DESCRIPTION
## Summary
- Convert navigation links to HTML anchors with `target="_blank"` so they open in a new browser tab

## Test plan
- [ ] Verify links render correctly on GitHub
- [ ] Verify links open in new tab when clicked

🤖 Generated with [Claude Code](https://claude.ai/claude-code)