### PR TITLE
Migrate XRCSVEncoder from Jackson to Gson; drop direct Jackson dependency

### DIFF
--- a/docs/superpowers/plans/2026-06-30-jackson-to-gson-migration.md
+++ b/docs/superpowers/plans/2026-06-30-jackson-to-gson-migration.md
@@ -98,20 +98,27 @@ public class XRCSVEncoderTest {
     }
 
     @Test
-    public void emptyExceptionColumnWhenNoThrowable() {
+    public void includesExceptionMessageWhenThrowablePresent() {
         LoggerContext context = new LoggerContext();
         Logger logger = context.getLogger("test.logger");
         XRCSVEncoder encoder = newStartedEncoder(context);
 
         LoggingEvent event = new LoggingEvent(
-                "org.jvmxray.Fqcn", logger, Level.WARN, "no throwable here", null, null);
+                "org.jvmxray.Fqcn", logger, Level.ERROR, "boom occurred",
+                new RuntimeException("kaboom"), null);
         event.setThreadName("worker-1");
         event.setTimeStamp(42L);
         event.setMDCPropertyMap(Collections.emptyMap());
 
         String csv = new String(encoder.encode(event));
 
-        assertTrue(csv.startsWith("42,WARN,worker-1,test.logger,"));
+        // Column order: timestamp,level,thread,logger,message,exception(,mdc...).
+        // With no MDC, the exception field is the last column, so the line ends with it.
+        // This exercises the JSON exception branch (the only path that reads
+        // node.has("exception") + the exception value back out).
+        assertTrue("prefix", csv.startsWith("42,ERROR,worker-1,test.logger,"));
+        assertTrue("exception column should carry the throwable message",
+                csv.endsWith("kaboom\n"));
     }
 }
 ```

--- a/docs/superpowers/plans/2026-06-30-jackson-to-gson-migration.md
+++ b/docs/superpowers/plans/2026-06-30-jackson-to-gson-migration.md
@@ -1,0 +1,341 @@
+# Jackson → Gson Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove all FasterXML Jackson (`com.fasterxml.jackson.*`) from the build, replacing the one real consumer (`XRCSVEncoder`) with Gson.
+
+**Architecture:** Jackson reaches the build through two paths — a direct `jackson-databind` dependency used only by `XRCSVEncoder`, and a transitive pull from the `logback-jackson` contrib add-on. Both are closed: `XRCSVEncoder` is rewritten against the Gson API (a 1:1 mechanical swap with byte-identical CSV output), and the unused `logback-jackson` + `logback-json-classic` contrib modules are deleted from the POM. Core logback (`logback-classic`/`logback-core`) never depended on Jackson and is untouched.
+
+**Tech Stack:** Java, Maven, JUnit 4.13.1, Gson 2.10.1, logback-classic 1.5.19.
+
+## Global Constraints
+
+- Gson version: exactly `2.10.1` (matches the mcp-server worktree).
+- Do **not** touch the `org.jvmxray.agent.sensor.serialization` package — it references Jackson by string class name for bytecode instrumentation of monitored apps; it is not a library dependency.
+- Do **not** add a Cassandra-driver exclusion — the transitive `org.codehaus.jackson:jackson-core-asl:1.9.12` (legacy, unrelated) is explicitly out of scope.
+- Preserve `XRCSVEncoder`'s output exactly: same CSV fields, same order, byte-for-byte.
+- Build must compile and the full `mvn test` suite must pass at each task's commit boundary.
+
+---
+
+## File Structure
+
+- `pom.xml` — remove 3 Jackson-related dependency blocks, add 1 Gson block.
+- `src/main/java/org/jvmxray/platform/shared/log/logback/codec/XRCSVEncoder.java` — swap Jackson API for Gson.
+- `src/test/java/org/jvmxray/platform/shared/log/logback/codec/XRCSVEncoderTest.java` — new characterization test (none exists today).
+
+---
+
+## Task 1: Characterization test for XRCSVEncoder
+
+Capture `XRCSVEncoder`'s current CSV output as a regression guard **before** changing anything. This is a refactor with identical output, so the test passes on the existing Jackson implementation (establishing the baseline) and must still pass after the Gson migration. It does not go "red" — that is correct for a behavior-preserving refactor.
+
+**Files:**
+- Test: `src/test/java/org/jvmxray/platform/shared/log/logback/codec/XRCSVEncoderTest.java`
+
+**Interfaces:**
+- Consumes: `XRCSVEncoder()` (no-arg ctor), `XRCSVEncoder.encode(ILoggingEvent): byte[]` (inherited public override).
+- Produces: nothing for later tasks (test-only).
+
+- [ ] **Step 1: Write the characterization test**
+
+Create `src/test/java/org/jvmxray/platform/shared/log/logback/codec/XRCSVEncoderTest.java`:
+
+```java
+package org.jvmxray.platform.shared.log.logback.codec;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.PatternLayout;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class XRCSVEncoderTest {
+
+    private XRCSVEncoder newStartedEncoder(LoggerContext context) {
+        PatternLayout layout = new PatternLayout();
+        layout.setContext(context);
+        layout.setPattern("%msg");
+        layout.start();
+
+        XRCSVEncoder encoder = new XRCSVEncoder();
+        encoder.setContext(context);
+        encoder.setLayout(layout);
+        encoder.start();
+        return encoder;
+    }
+
+    @Test
+    public void encodesCoreFieldsAsCsv() {
+        LoggerContext context = new LoggerContext();
+        Logger logger = context.getLogger("test.logger");
+        XRCSVEncoder encoder = newStartedEncoder(context);
+
+        LoggingEvent event = new LoggingEvent(
+                "org.jvmxray.Fqcn", logger, Level.INFO, "hello world", null, null);
+        event.setThreadName("main");
+        event.setTimeStamp(1234567890L);
+
+        String csv = new String(encoder.encode(event));
+        // CSV column order: timestamp,level,thread,logger,message,exception,<mdc...>
+        // Columns 0-3 precede the message and contain no commas, so split(",") is safe for them.
+        String[] cols = csv.split(",");
+
+        assertEquals("1234567890", cols[0]);
+        assertEquals("INFO", cols[1]);
+        assertEquals("main", cols[2]);
+        assertEquals("test.logger", cols[3]);
+        assertTrue("CSV should end with newline", csv.endsWith("\n"));
+    }
+
+    @Test
+    public void emptyExceptionColumnWhenNoThrowable() {
+        LoggerContext context = new LoggerContext();
+        Logger logger = context.getLogger("test.logger");
+        XRCSVEncoder encoder = newStartedEncoder(context);
+
+        LoggingEvent event = new LoggingEvent(
+                "org.jvmxray.Fqcn", logger, Level.WARN, "no throwable here", null, null);
+        event.setThreadName("worker-1");
+        event.setTimeStamp(42L);
+
+        String csv = new String(encoder.encode(event));
+
+        assertTrue(csv.startsWith("42,WARN,worker-1,test.logger,"));
+    }
+}
+```
+
+- [ ] **Step 2: Run the test against the current (Jackson) implementation**
+
+Run: `mvn test -Dtest=XRCSVEncoderTest`
+Expected: PASS (2 tests). This confirms the test correctly characterizes current behavior.
+
+If it fails, stop — the test assumptions are wrong and must be fixed before migrating, otherwise it cannot guard the refactor.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/test/java/org/jvmxray/platform/shared/log/logback/codec/XRCSVEncoderTest.java
+git commit -m "test: add XRCSVEncoder characterization test before Gson migration
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Remove unused logback-jackson and logback-json-classic dependencies
+
+These two `logback.contrib` add-ons exist only to provide a Jackson-backed JSON layout. No logback config references a JSON layout, so they are dead weight. `logback-jackson` is also Jackson's "Door B" (it pulls `jackson-databind` transitively). Removing them is an independent, code-free change verifiable on its own.
+
+**Files:**
+- Modify: `pom.xml` (the two `ch.qos.logback.contrib` dependency blocks, currently around lines 73–82)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing for later tasks.
+
+- [ ] **Step 1: Remove the two contrib dependency blocks**
+
+Delete these two blocks from `pom.xml`:
+
+```xml
+    <dependency>
+      <groupId>ch.qos.logback.contrib</groupId>
+      <artifactId>logback-json-classic</artifactId>
+      <version>0.1.5</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback.contrib</groupId>
+      <artifactId>logback-jackson</artifactId>
+      <version>0.1.5</version>
+    </dependency>
+```
+
+Leave the `logback-classic` and `logback-core` dependencies and the `<!-- JSON -->` `jackson-databind` block untouched (jackson-databind is handled in Task 3).
+
+- [ ] **Step 2: Verify logback-jackson and logback-json-classic are gone from the tree**
+
+Run: `mvn dependency:tree | grep -iE "logback-jackson|logback-json"`
+Expected: no output (both removed). `logback-classic` and `logback-core` remain — verify with `mvn dependency:tree | grep -i "logback-c"` which should still list both.
+
+- [ ] **Step 3: Run the full test suite to prove logging still initializes**
+
+Run: `mvn test`
+Expected: BUILD SUCCESS. Every logback config is loaded during tests; a green run confirms the contrib removal broke nothing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pom.xml
+git commit -m "build: remove unused logback-jackson and logback-json-classic deps
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Migrate XRCSVEncoder to Gson and swap the Jackson dependency
+
+Atomic change: the encoder rewrite and the dependency swap must land together so the build always compiles (removing jackson-databind while the encoder still imports Jackson would break compilation, and vice versa).
+
+**Files:**
+- Modify: `pom.xml` (the `<!-- JSON -->` `jackson-databind` block)
+- Modify: `src/main/java/org/jvmxray/platform/shared/log/logback/codec/XRCSVEncoder.java`
+
+**Interfaces:**
+- Consumes: `XRCSVEncoderTest` from Task 1 (the regression guard).
+- Produces: `XRCSVEncoder` with unchanged public surface (`encode(ILoggingEvent): byte[]`).
+
+- [ ] **Step 1: Swap the dependency in pom.xml**
+
+Replace the `<!-- JSON -->` block:
+
+```xml
+    <!-- JSON -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.17.1</version>
+    </dependency>
+```
+
+with:
+
+```xml
+    <!-- JSON -->
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.10.1</version>
+    </dependency>
+```
+
+- [ ] **Step 2: Rewrite XRCSVEncoder against the Gson API**
+
+Replace the entire contents of `src/main/java/org/jvmxray/platform/shared/log/logback/codec/XRCSVEncoder.java` with:
+
+```java
+package org.jvmxray.platform.shared.log.logback.codec;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
+import com.google.gson.JsonObject;
+
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Map;
+
+/**
+ * Encoder for CSVFiles ensures any data with commas is properly
+ * escaped prior to logging.  It's intended to help cleanup
+ * machine logs for better parsing.
+ * @author Milton Smith
+ */
+public class XRCSVEncoder extends LayoutWrappingEncoder {
+
+    private static final char CSV_DELIMITER = ',';
+    private static Charset charset = Charset.forName("UTF-8");
+
+    public XRCSVEncoder() {
+        super();
+    }
+
+    public byte[] encode(ILoggingEvent event) {
+        String formattedMessage = Arrays.toString(super.encode(event));
+        return (toCsv(formattedMessage, toJson(event, event.getMDCPropertyMap()), event) + "\n").getBytes(charset);
+    }
+
+    private String toCsv(String formattedMessage, JsonObject node, ILoggingEvent event) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(node.get("timestamp").getAsLong()).append(CSV_DELIMITER);
+        builder.append(node.get("level").getAsString()).append(CSV_DELIMITER);
+        builder.append(node.get("thread").getAsString()).append(CSV_DELIMITER);
+        builder.append(node.get("logger").getAsString()).append(CSV_DELIMITER);
+        builder.append(formattedMessage.replace(",", "\\,")).append(CSV_DELIMITER); // use formattedMessage here
+        if (node.has("exception")) {
+            builder.append(node.get("exception").getAsString().replace(",", "\\,")).append(CSV_DELIMITER);
+        } else {
+            builder.append(CSV_DELIMITER);
+        }
+        // add MDC values to CSV
+        for (Map.Entry<String, String> entry : event.getMDCPropertyMap().entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            builder.append(value.replace(",", "\\,")).append(CSV_DELIMITER);
+        }
+        builder.setLength(builder.length() - 1); // remove last delimiter
+        return builder.toString();
+    }
+
+    private JsonObject toJson(ILoggingEvent event, Map<String, String> mdcProperties) {
+        JsonObject node = new JsonObject();
+        node.addProperty("timestamp", event.getTimeStamp());
+        node.addProperty("level", event.getLevel().toString());
+        node.addProperty("thread", event.getThreadName());
+        node.addProperty("logger", event.getLoggerName());
+        node.addProperty("message", event.getFormattedMessage());
+        if (event.getThrowableProxy() != null) {
+            node.addProperty("exception", event.getThrowableProxy().getMessage());
+        }
+        if (mdcProperties != null) {
+            for (Map.Entry<String, String> entry : mdcProperties.entrySet()) {
+                node.addProperty(entry.getKey(), entry.getValue());
+            }
+        }
+        return node;
+    }
+
+
+}
+```
+
+Note: the only changes from the original are the three import lines (`com.fasterxml.jackson.databind.*` → `com.google.gson.JsonObject`), the `JsonNode`/`ObjectNode` types → `JsonObject`, `mapper.createObjectNode()` → `new JsonObject()`, `put(...)` → `addProperty(...)`, `asLong()` → `getAsLong()`, and `asText()` → `getAsString()`. The pre-existing unused `key` local is left as-is (surgical change — do not clean up pre-existing code).
+
+- [ ] **Step 3: Verify zero FasterXML Jackson remains in the build**
+
+Run: `mvn dependency:tree | grep -i "com.fasterxml.jackson"`
+Expected: no output (zero entries).
+
+Then confirm Gson is present:
+Run: `mvn dependency:tree | grep -i "com.google.code.gson"`
+Expected: one line showing `gson:jar:2.10.1`.
+
+(The legacy `org.codehaus.jackson:jackson-core-asl:1.9.12` may still appear — out of scope, expected.)
+
+- [ ] **Step 4: Run the characterization test to confirm identical behavior**
+
+Run: `mvn test -Dtest=XRCSVEncoderTest`
+Expected: PASS (2 tests) — same result as Task 1, proving the CSV output is unchanged.
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `mvn test`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pom.xml src/main/java/org/jvmxray/platform/shared/log/logback/codec/XRCSVEncoder.java
+git commit -m "refactor: migrate XRCSVEncoder from Jackson to Gson
+
+Removes the direct jackson-databind dependency; XRCSVEncoder now builds
+its JSON view with Gson. CSV output is unchanged.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification
+
+After all tasks:
+
+- [ ] `mvn dependency:tree | grep -i "com.fasterxml.jackson"` → no output.
+- [ ] `mvn dependency:tree | grep -iE "logback-jackson|logback-json"` → no output.
+- [ ] `mvn test` → BUILD SUCCESS.
+- [ ] `git log --oneline -4` shows the three migration commits plus the design-spec commit.

--- a/docs/superpowers/plans/2026-06-30-jackson-to-gson-migration.md
+++ b/docs/superpowers/plans/2026-06-30-jackson-to-gson-migration.md
@@ -51,6 +51,8 @@ import ch.qos.logback.classic.PatternLayout;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import org.junit.Test;
 
+import java.util.Collections;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -79,6 +81,9 @@ public class XRCSVEncoderTest {
                 "org.jvmxray.Fqcn", logger, Level.INFO, "hello world", null, null);
         event.setThreadName("main");
         event.setTimeStamp(1234567890L);
+        // A hand-built LoggingEvent has no MDC map; real logback always sets one.
+        // Without this, encode() NPEs iterating a null MDC map.
+        event.setMDCPropertyMap(Collections.emptyMap());
 
         String csv = new String(encoder.encode(event));
         // CSV column order: timestamp,level,thread,logger,message,exception,<mdc...>
@@ -102,6 +107,7 @@ public class XRCSVEncoderTest {
                 "org.jvmxray.Fqcn", logger, Level.WARN, "no throwable here", null, null);
         event.setThreadName("worker-1");
         event.setTimeStamp(42L);
+        event.setMDCPropertyMap(Collections.emptyMap());
 
         String csv = new String(encoder.encode(event));
 

--- a/docs/superpowers/plans/2026-06-30-jackson-to-gson-migration.md
+++ b/docs/superpowers/plans/2026-06-30-jackson-to-gson-migration.md
@@ -120,8 +120,33 @@ public class XRCSVEncoderTest {
         assertTrue("exception column should carry the throwable message",
                 csv.endsWith("kaboom\n"));
     }
+
+    @Test
+    public void nullExceptionMessageDoesNotCrash() {
+        LoggerContext context = new LoggerContext();
+        Logger logger = context.getLogger("test.logger");
+        XRCSVEncoder encoder = newStartedEncoder(context);
+
+        // A throwable whose getMessage() is null. Under Gson, addProperty(k, null) stores
+        // JsonNull and getAsString() throws — so the encoder must guard this. The exception
+        // column is emitted empty (byte-identical to the no-exception else branch).
+        LoggingEvent event = new LoggingEvent(
+                "org.jvmxray.Fqcn", logger, Level.ERROR, "boom", new RuntimeException(), null);
+        event.setThreadName("worker-1");
+        event.setTimeStamp(7L);
+        event.setMDCPropertyMap(Collections.emptyMap());
+
+        String csv = new String(encoder.encode(event));
+
+        assertTrue("prefix", csv.startsWith("7,ERROR,worker-1,test.logger,"));
+        assertTrue("line terminated", csv.endsWith("\n"));
+    }
 }
 ```
+
+Note (added during execution): this third test is a true regression guard — it fails (throws
+`UnsupportedOperationException`) against an unguarded Gson port and passes once the null-message
+guard in `toJson` is in place.
 
 - [ ] **Step 2: Run the test against the current (Jackson) implementation**
 
@@ -293,7 +318,14 @@ public class XRCSVEncoder extends LayoutWrappingEncoder {
         node.addProperty("logger", event.getLoggerName());
         node.addProperty("message", event.getFormattedMessage());
         if (event.getThrowableProxy() != null) {
-            node.addProperty("exception", event.getThrowableProxy().getMessage());
+            // Gson's addProperty(String, null) stores JsonNull, and getAsString() on it
+            // throws (unlike Jackson, which stored a NullNode). A throwable with a null
+            // message (e.g. new NullPointerException()) would otherwise crash the encoder.
+            // Omitting the field yields a byte-identical empty exception column.
+            String exceptionMessage = event.getThrowableProxy().getMessage();
+            if (exceptionMessage != null) {
+                node.addProperty("exception", exceptionMessage);
+            }
         }
         if (mdcProperties != null) {
             for (Map.Entry<String, String> entry : mdcProperties.entrySet()) {
@@ -307,7 +339,7 @@ public class XRCSVEncoder extends LayoutWrappingEncoder {
 }
 ```
 
-Note: the only changes from the original are the three import lines (`com.fasterxml.jackson.databind.*` → `com.google.gson.JsonObject`), the `JsonNode`/`ObjectNode` types → `JsonObject`, `mapper.createObjectNode()` → `new JsonObject()`, `put(...)` → `addProperty(...)`, `asLong()` → `getAsLong()`, and `asText()` → `getAsString()`. The pre-existing unused `key` local is left as-is (surgical change — do not clean up pre-existing code).
+Note: the changes from the original are the three import lines (`com.fasterxml.jackson.databind.*` → `com.google.gson.JsonObject`), the `JsonNode`/`ObjectNode` types → `JsonObject`, `mapper.createObjectNode()` → `new JsonObject()`, `put(...)` → `addProperty(...)`, `asLong()` → `getAsLong()`, `asText()` → `getAsString()`, and the null-message guard on the exception field (Gson's `addProperty(k, null)` stores `JsonNull`, whose `getAsString()` throws — unlike Jackson's `NullNode`). The pre-existing unused `key` local is left as-is (surgical change — do not clean up pre-existing code).
 
 - [ ] **Step 3: Verify zero FasterXML Jackson remains in the build**
 

--- a/docs/superpowers/specs/2026-06-30-jackson-to-gson-migration-design.md
+++ b/docs/superpowers/specs/2026-06-30-jackson-to-gson-migration-design.md
@@ -1,0 +1,115 @@
+# Migrate FasterXML Jackson → Gson
+
+**Date:** 2026-06-30
+**Status:** Approved (design)
+
+## Goal
+
+Remove all **FasterXML Jackson** (`com.fasterxml.jackson.*`) from the build, replacing the
+one real consumer with Gson. After this change, `mvn dependency:tree` shows zero
+`com.fasterxml.jackson` entries.
+
+## Scope
+
+### In scope
+- Replace Jackson API usage in `XRCSVEncoder.java` with Gson.
+- Remove the direct `jackson-databind` dependency from `pom.xml`.
+- Remove the two `logback.contrib` add-ons that exist only to provide a Jackson-backed JSON
+  layout: `logback-jackson` and `logback-json-classic`.
+- Add `com.google.code.gson:gson` (version `2.10.1`, matching the mcp-server worktree).
+
+### Out of scope
+- **Legacy Codehaus Jackson** (`org.codehaus.jackson:jackson-core-asl:1.9.12`). This is a
+  different, unrelated library pulled in transitively through the Cassandra driver
+  (`com.datastax.oss:java-driver-core` → `com.esri.geometry:esri-geometry-api`). Removing it
+  would require an exclusion on the Cassandra driver and risks breaking `esri-geometry-api` at
+  runtime. Left untouched by explicit decision.
+- **The `serialization` sensor package** (`JacksonInterceptor`, `SerializationInterceptor`,
+  `SerializationSensor`). These reference Jackson by *string class name* to bytecode-instrument
+  and detect Jackson usage in monitored target applications. Jackson is not a library
+  dependency there; changing it would break detection. Left untouched.
+
+## Background: how Jackson enters the build
+
+Jackson reaches the build through two independent paths ("doors"):
+
+- **Door A — direct declaration.** `pom.xml` lists `com.fasterxml.jackson.core:jackson-databind:2.17.1`
+  directly. Its only consumer is `XRCSVEncoder`.
+- **Door B — transitive via `logback-jackson`.** The `ch.qos.logback.contrib:logback-jackson:0.1.5`
+  POM declares `jackson-databind` as a plain `compile` dependency. So Jackson comes along even if
+  Door A is closed.
+
+Logback itself does **not** depend on Jackson. The dependency layering is:
+
+```
+logback-core                 → (no Jackson)        ← the engine
+logback-classic              → logback-core         (no Jackson)
+logback-json-core (contrib)  → logback-core         (no Jackson)
+logback-json-classic (contrib) → logback-classic, logback-json-core   (no Jackson)
+logback-jackson (contrib)    → logback-json-core, jackson-databind     ← Jackson door
+```
+
+Closing both doors requires removing the direct `jackson-databind` **and** `logback-jackson`.
+`logback-json-classic` only provided a JSON layout that `logback-jackson` formats; with the
+formatter gone it has no purpose, so it is removed too.
+
+## Why this is safe for logback
+
+Verified against the codebase, not assumed:
+
+1. `logback-classic` and `logback-core` are declared as their own direct dependencies and are
+   untouched. They never depended on Jackson.
+2. None of the 8 logback config files (`src/main/resources` + `src/test/resources`, including
+   production / shaded / test variants) reference a JSON layout. A grep for
+   `json|jackson|contrib` across all of them returns zero matches. Every appender is a stock
+   `ConsoleAppender` / `FileAppender` / `RollingFileAppender` (or the project's custom
+   SQLite/Cassandra appenders) using the default `PatternLayoutEncoder`.
+3. `logback-jackson` / `logback-json-classic` depend *on* logback, not the reverse. Removing the
+   leaves cannot affect the trunk.
+
+The `logback.contrib` JSON layout is not Gson-pluggable — its formatter SPI is Jackson-specific
+and there is no `logback-gson` adapter in this stack. Because no config uses the JSON layout,
+nothing is lost by dropping it; we are not "swapping Gson into logback," we are removing dead
+add-ons.
+
+## Changes
+
+### 1. `pom.xml`
+
+- **Remove** `com.fasterxml.jackson.core:jackson-databind:2.17.1`
+- **Remove** `ch.qos.logback.contrib:logback-jackson:0.1.5`
+- **Remove** `ch.qos.logback.contrib:logback-json-classic:0.1.5`
+- **Add** `com.google.code.gson:gson:2.10.1`
+
+### 2. `XRCSVEncoder.java`
+
+Mechanical 1:1 API swap inside the existing `toJson(...)` and `toCsv(...)` private methods. No
+behavior change; output CSV is byte-for-byte identical (same fields, same order).
+
+| Jackson | Gson |
+|---|---|
+| `ObjectMapper` + `mapper.createObjectNode()` | `new JsonObject()` |
+| `node.put(k, v)` | `node.addProperty(k, v)` |
+| `JsonNode` / `ObjectNode` types | `JsonObject` / `JsonElement` |
+| `node.get("x").asLong()` | `node.get("x").getAsLong()` |
+| `node.get("x").asText()` | `node.get("x").getAsString()` |
+| `node.has("x")` | `node.has("x")` (unchanged) |
+
+Imports change from `com.fasterxml.jackson.databind.*` to `com.google.gson.*`.
+
+### Note on dead code
+
+`XRCSVEncoder`, `logback-jackson`, and `logback-json-classic` all appear to be dead/unused — no
+logback config or code wires them in. Per the project request this design **migrates**
+`XRCSVEncoder` to Gson rather than deleting it. (Deleting the encoder instead would shrink the
+work to the POM changes alone; not chosen.)
+
+## Success criteria / verification
+
+1. `mvn dependency:tree` shows **zero `com.fasterxml.jackson`** entries. (Codehaus 1.x may
+   remain — out of scope.)
+2. `mvn compile` succeeds.
+3. The full `mvn test` suite passes. This exercises every logback config during initialization,
+   empirically confirming the contrib removal broke nothing.
+4. A small unit test for `XRCSVEncoder` asserts the produced CSV is correct (the class currently
+   has no test and its only consumer is being rewritten).

--- a/docs/superpowers/specs/2026-06-30-jackson-to-gson-migration-design.md
+++ b/docs/superpowers/specs/2026-06-30-jackson-to-gson-migration-design.md
@@ -5,9 +5,20 @@
 
 ## Goal
 
-Remove all **FasterXML Jackson** (`com.fasterxml.jackson.*`) from the build, replacing the
-one real consumer with Gson. After this change, `mvn dependency:tree` shows zero
-`com.fasterxml.jackson` entries.
+Remove the project's **direct** dependency on FasterXML Jackson, replacing the one real
+consumer with Gson. After this change, the project declares no Jackson dependency of its own
+and no project code imports the Jackson API.
+
+> **Scope clarification (added during execution):** The original goal stated "`mvn
+> dependency:tree` shows zero `com.fasterxml.jackson` entries." That is not achievable here and
+> is not the real objective. Removing our direct `jackson-databind:2.17.1` unmasked a
+> *transitive* FasterXML Jackson (`jackson-core`/`jackson-databind:2.12.2`) that the Cassandra
+> driver (`com.datastax.oss:java-driver-core:4.13.0`) declares for its own use — Maven's
+> nearest-wins mediation had hidden it behind our direct, newer copy. Per project policy,
+> **direct** Jackson dependencies are removed (this migration); **transitive** Jackson owned by
+> 3rd-party jars is a *separate* effort addressed by upgrading or replacing the offending jar,
+> proposed and reviewed with the user as a tradeoff — not by blanket Maven exclusions. See
+> "Follow-up: transitive Jackson" below.
 
 ## Scope
 
@@ -18,12 +29,14 @@ one real consumer with Gson. After this change, `mvn dependency:tree` shows zero
   layout: `logback-jackson` and `logback-json-classic`.
 - Add `com.google.code.gson:gson` (version `2.10.1`, matching the mcp-server worktree).
 
-### Out of scope
-- **Legacy Codehaus Jackson** (`org.codehaus.jackson:jackson-core-asl:1.9.12`). This is a
-  different, unrelated library pulled in transitively through the Cassandra driver
-  (`com.datastax.oss:java-driver-core` → `com.esri.geometry:esri-geometry-api`). Removing it
-  would require an exclusion on the Cassandra driver and risks breaking `esri-geometry-api` at
-  runtime. Left untouched by explicit decision.
+### Out of scope (transitive Jackson — see follow-up)
+- **FasterXML Jackson `2.12.2` via the Cassandra driver** (`com.datastax.oss:java-driver-core:4.13.0`
+  → `jackson-core`/`jackson-databind`). The driver depends on Jackson for its own JSON handling.
+  Transitive; addressed separately by upgrading/replacing the driver, not by this migration.
+- **Legacy Codehaus Jackson** (`org.codehaus.jackson:jackson-core-asl:1.9.12`). A different,
+  unrelated library pulled in transitively through the Cassandra driver
+  (`com.datastax.oss:java-driver-core` → `com.esri.geometry:esri-geometry-api`). Transitive;
+  same follow-up strategy.
 - **The `serialization` sensor package** (`JacksonInterceptor`, `SerializationInterceptor`,
   `SerializationSensor`). These reference Jackson by *string class name* to bytecode-instrument
   and detect Jackson usage in monitored target applications. Jackson is not a library
@@ -106,10 +119,30 @@ work to the POM changes alone; not chosen.)
 
 ## Success criteria / verification
 
-1. `mvn dependency:tree` shows **zero `com.fasterxml.jackson`** entries. (Codehaus 1.x may
-   remain — out of scope.)
-2. `mvn compile` succeeds.
-3. The full `mvn test` suite passes. This exercises every logback config during initialization,
+1. `pom.xml` declares **no** `com.fasterxml.jackson` dependency and no project code imports the
+   Jackson API. (`grep -rn "com.fasterxml.jackson" src/main pom.xml` returns only the
+   `serialization` sensor's string class-name references, which are out of scope.) Any remaining
+   `com.fasterxml.jackson` in `mvn dependency:tree` is transitive via 3rd-party jars (Cassandra
+   driver) — tracked under Follow-up, not a blocker here.
+2. `mvn dependency:tree` shows `com.google.code.gson:gson:2.10.1` present.
+3. `mvn compile` succeeds.
+4. The full `mvn test` suite passes. This exercises every logback config during initialization,
    empirically confirming the contrib removal broke nothing.
-4. A small unit test for `XRCSVEncoder` asserts the produced CSV is correct (the class currently
+5. A small unit test for `XRCSVEncoder` asserts the produced CSV is correct (the class currently
    has no test and its only consumer is being rewritten).
+
+## Follow-up: transitive Jackson (separate effort)
+
+After this migration, FasterXML Jackson `2.12.2` (and legacy Codehaus `jackson-core-asl:1.9.12`)
+remain in the tree transitively, both owned by `com.datastax.oss:java-driver-core:4.13.0` (the
+Codehaus one via its `esri-geometry-api` dependency). Project policy is to treat Jackson as
+systemically vulnerable and avoid it where practical, but transitive copies are not removed by
+blanket Maven `<exclusion>`s. They are addressed as a **separate, user-reviewed tradeoff**:
+
+- **Option A — upgrade the Cassandra driver** to a newer `java-driver-core` that bundles a newer,
+  less-vulnerable Jackson (and may drop the Codehaus path). Lower-risk, stays on DataStax.
+- **Option B — replace the driver** with an equivalent Cassandra client that doesn't pull Jackson.
+  Larger change; eliminates Jackson but higher migration cost/risk.
+
+This is to be proposed and reviewed with the user before any action; it is intentionally **not**
+part of this migration.

--- a/pom.xml
+++ b/pom.xml
@@ -72,9 +72,9 @@
     </dependency>
     <!-- JSON -->
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.17.1</version>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.10.1</version>
     </dependency>
 
     <!-- Database drivers -->

--- a/pom.xml
+++ b/pom.xml
@@ -70,17 +70,6 @@
       <artifactId>slf4j-api</artifactId>
       <version>2.0.13</version>
     </dependency>
-    <dependency>
-      <groupId>ch.qos.logback.contrib</groupId>
-      <artifactId>logback-json-classic</artifactId>
-      <version>0.1.5</version>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback.contrib</groupId>
-      <artifactId>logback-jackson</artifactId>
-      <version>0.1.5</version>
-    </dependency>
-
     <!-- JSON -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/org/jvmxray/platform/shared/log/logback/codec/XRCSVEncoder.java
+++ b/src/main/java/org/jvmxray/platform/shared/log/logback/codec/XRCSVEncoder.java
@@ -58,7 +58,14 @@ public class XRCSVEncoder extends LayoutWrappingEncoder {
         node.addProperty("logger", event.getLoggerName());
         node.addProperty("message", event.getFormattedMessage());
         if (event.getThrowableProxy() != null) {
-            node.addProperty("exception", event.getThrowableProxy().getMessage());
+            // Gson's addProperty(String, null) stores JsonNull, and getAsString() on it
+            // throws (unlike Jackson, which stored a NullNode). A throwable with a null
+            // message (e.g. new NullPointerException()) would otherwise crash the encoder.
+            // Omitting the field yields a byte-identical empty exception column.
+            String exceptionMessage = event.getThrowableProxy().getMessage();
+            if (exceptionMessage != null) {
+                node.addProperty("exception", exceptionMessage);
+            }
         }
         if (mdcProperties != null) {
             for (Map.Entry<String, String> entry : mdcProperties.entrySet()) {

--- a/src/main/java/org/jvmxray/platform/shared/log/logback/codec/XRCSVEncoder.java
+++ b/src/main/java/org/jvmxray/platform/shared/log/logback/codec/XRCSVEncoder.java
@@ -2,9 +2,7 @@ package org.jvmxray.platform.shared.log.logback.codec;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.gson.JsonObject;
 
 import java.nio.charset.Charset;
 import java.util.Arrays;
@@ -30,15 +28,15 @@ public class XRCSVEncoder extends LayoutWrappingEncoder {
         return (toCsv(formattedMessage, toJson(event, event.getMDCPropertyMap()), event) + "\n").getBytes(charset);
     }
 
-    private String toCsv(String formattedMessage, JsonNode node, ILoggingEvent event) {
+    private String toCsv(String formattedMessage, JsonObject node, ILoggingEvent event) {
         StringBuilder builder = new StringBuilder();
-        builder.append(node.get("timestamp").asLong()).append(CSV_DELIMITER);
-        builder.append(node.get("level").asText()).append(CSV_DELIMITER);
-        builder.append(node.get("thread").asText()).append(CSV_DELIMITER);
-        builder.append(node.get("logger").asText()).append(CSV_DELIMITER);
+        builder.append(node.get("timestamp").getAsLong()).append(CSV_DELIMITER);
+        builder.append(node.get("level").getAsString()).append(CSV_DELIMITER);
+        builder.append(node.get("thread").getAsString()).append(CSV_DELIMITER);
+        builder.append(node.get("logger").getAsString()).append(CSV_DELIMITER);
         builder.append(formattedMessage.replace(",", "\\,")).append(CSV_DELIMITER); // use formattedMessage here
         if (node.has("exception")) {
-            builder.append(node.get("exception").asText().replace(",", "\\,")).append(CSV_DELIMITER);
+            builder.append(node.get("exception").getAsString().replace(",", "\\,")).append(CSV_DELIMITER);
         } else {
             builder.append(CSV_DELIMITER);
         }
@@ -52,20 +50,19 @@ public class XRCSVEncoder extends LayoutWrappingEncoder {
         return builder.toString();
     }
 
-    private JsonNode toJson(ILoggingEvent event, Map<String, String> mdcProperties) {
-        ObjectMapper mapper = new ObjectMapper();
-        ObjectNode node = mapper.createObjectNode();
-        node.put("timestamp", event.getTimeStamp());
-        node.put("level", event.getLevel().toString());
-        node.put("thread", event.getThreadName());
-        node.put("logger", event.getLoggerName());
-        node.put("message", event.getFormattedMessage());
+    private JsonObject toJson(ILoggingEvent event, Map<String, String> mdcProperties) {
+        JsonObject node = new JsonObject();
+        node.addProperty("timestamp", event.getTimeStamp());
+        node.addProperty("level", event.getLevel().toString());
+        node.addProperty("thread", event.getThreadName());
+        node.addProperty("logger", event.getLoggerName());
+        node.addProperty("message", event.getFormattedMessage());
         if (event.getThrowableProxy() != null) {
-            node.put("exception", event.getThrowableProxy().getMessage());
+            node.addProperty("exception", event.getThrowableProxy().getMessage());
         }
         if (mdcProperties != null) {
             for (Map.Entry<String, String> entry : mdcProperties.entrySet()) {
-                node.put(entry.getKey(), entry.getValue());
+                node.addProperty(entry.getKey(), entry.getValue());
             }
         }
         return node;

--- a/src/test/java/org/jvmxray/platform/shared/log/logback/codec/XRCSVEncoderTest.java
+++ b/src/test/java/org/jvmxray/platform/shared/log/logback/codec/XRCSVEncoderTest.java
@@ -76,4 +76,25 @@ public class XRCSVEncoderTest {
         assertTrue("exception column should carry the throwable message",
                 csv.endsWith("kaboom\n"));
     }
+
+    @Test
+    public void nullExceptionMessageDoesNotCrash() {
+        LoggerContext context = new LoggerContext();
+        Logger logger = context.getLogger("test.logger");
+        XRCSVEncoder encoder = newStartedEncoder(context);
+
+        // A throwable whose getMessage() is null. Under Gson, addProperty(k, null) stores
+        // JsonNull and getAsString() throws — so the encoder must guard this. The exception
+        // column is emitted empty (byte-identical to the no-exception else branch).
+        LoggingEvent event = new LoggingEvent(
+                "org.jvmxray.Fqcn", logger, Level.ERROR, "boom", new RuntimeException(), null);
+        event.setThreadName("worker-1");
+        event.setTimeStamp(7L);
+        event.setMDCPropertyMap(Collections.emptyMap());
+
+        String csv = new String(encoder.encode(event));
+
+        assertTrue("prefix", csv.startsWith("7,ERROR,worker-1,test.logger,"));
+        assertTrue("line terminated", csv.endsWith("\n"));
+    }
 }

--- a/src/test/java/org/jvmxray/platform/shared/log/logback/codec/XRCSVEncoderTest.java
+++ b/src/test/java/org/jvmxray/platform/shared/log/logback/codec/XRCSVEncoderTest.java
@@ -1,0 +1,72 @@
+package org.jvmxray.platform.shared.log.logback.codec;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.PatternLayout;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class XRCSVEncoderTest {
+
+    private XRCSVEncoder newStartedEncoder(LoggerContext context) {
+        PatternLayout layout = new PatternLayout();
+        layout.setContext(context);
+        layout.setPattern("%msg");
+        layout.start();
+
+        XRCSVEncoder encoder = new XRCSVEncoder();
+        encoder.setContext(context);
+        encoder.setLayout(layout);
+        encoder.start();
+        return encoder;
+    }
+
+    @Test
+    public void encodesCoreFieldsAsCsv() {
+        LoggerContext context = new LoggerContext();
+        Logger logger = context.getLogger("test.logger");
+        XRCSVEncoder encoder = newStartedEncoder(context);
+
+        LoggingEvent event = new LoggingEvent(
+                "org.jvmxray.Fqcn", logger, Level.INFO, "hello world", null, null);
+        event.setThreadName("main");
+        event.setTimeStamp(1234567890L);
+        // A hand-built LoggingEvent has no MDC map; real logback always sets one.
+        // Without this, encode() NPEs iterating a null MDC map.
+        event.setMDCPropertyMap(Collections.emptyMap());
+
+        String csv = new String(encoder.encode(event));
+        // CSV column order: timestamp,level,thread,logger,message,exception,<mdc...>
+        // Columns 0-3 precede the message and contain no commas, so split(",") is safe for them.
+        String[] cols = csv.split(",");
+
+        assertEquals("1234567890", cols[0]);
+        assertEquals("INFO", cols[1]);
+        assertEquals("main", cols[2]);
+        assertEquals("test.logger", cols[3]);
+        assertTrue("CSV should end with newline", csv.endsWith("\n"));
+    }
+
+    @Test
+    public void emptyExceptionColumnWhenNoThrowable() {
+        LoggerContext context = new LoggerContext();
+        Logger logger = context.getLogger("test.logger");
+        XRCSVEncoder encoder = newStartedEncoder(context);
+
+        LoggingEvent event = new LoggingEvent(
+                "org.jvmxray.Fqcn", logger, Level.WARN, "no throwable here", null, null);
+        event.setThreadName("worker-1");
+        event.setTimeStamp(42L);
+        event.setMDCPropertyMap(Collections.emptyMap());
+
+        String csv = new String(encoder.encode(event));
+
+        assertTrue(csv.startsWith("42,WARN,worker-1,test.logger,"));
+    }
+}

--- a/src/test/java/org/jvmxray/platform/shared/log/logback/codec/XRCSVEncoderTest.java
+++ b/src/test/java/org/jvmxray/platform/shared/log/logback/codec/XRCSVEncoderTest.java
@@ -54,19 +54,26 @@ public class XRCSVEncoderTest {
     }
 
     @Test
-    public void emptyExceptionColumnWhenNoThrowable() {
+    public void includesExceptionMessageWhenThrowablePresent() {
         LoggerContext context = new LoggerContext();
         Logger logger = context.getLogger("test.logger");
         XRCSVEncoder encoder = newStartedEncoder(context);
 
         LoggingEvent event = new LoggingEvent(
-                "org.jvmxray.Fqcn", logger, Level.WARN, "no throwable here", null, null);
+                "org.jvmxray.Fqcn", logger, Level.ERROR, "boom occurred",
+                new RuntimeException("kaboom"), null);
         event.setThreadName("worker-1");
         event.setTimeStamp(42L);
         event.setMDCPropertyMap(Collections.emptyMap());
 
         String csv = new String(encoder.encode(event));
 
-        assertTrue(csv.startsWith("42,WARN,worker-1,test.logger,"));
+        // Column order: timestamp,level,thread,logger,message,exception(,mdc...).
+        // With no MDC, the exception field is the last column, so the line ends with it.
+        // This exercises the JSON exception branch (the only path that reads
+        // node.has("exception") + the exception value back out).
+        assertTrue("prefix", csv.startsWith("42,ERROR,worker-1,test.logger,"));
+        assertTrue("exception column should carry the throwable message",
+                csv.endsWith("kaboom\n"));
     }
 }


### PR DESCRIPTION
## Summary

Removes the project's **direct** dependency on FasterXML Jackson and migrates its only consumer to Gson, as part of the policy to avoid Jackson where practical.

- `XRCSVEncoder` (logback CSV encoder) rewritten from the Jackson API (`ObjectMapper`/`ObjectNode`/`JsonNode`) to Gson (`JsonObject`). Output CSV is byte-for-byte identical, with one deliberate edge-case fix.
- `pom.xml`: removed `com.fasterxml.jackson.core:jackson-databind`, plus the unused `ch.qos.logback.contrib:logback-jackson` and `logback-json-classic` add-ons; added `com.google.code.gson:gson:2.10.1` (matching the mcp-server module).
- Added `XRCSVEncoderTest` (3 tests) as a characterization/regression guard — none existed before.

## Edge case fixed during migration

Gson's `addProperty(key, null)` stores `JsonNull`, whose `getAsString()` throws (unlike Jackson's `NullNode`). A throwable with a null message (e.g. `new NullPointerException()`) would have crashed the encoder. The exception field is now omitted when the message is null, yielding a byte-identical empty column. Covered by `nullExceptionMessageDoesNotCrash`.

## Out of scope (follow-up)

A **transitive** FasterXML Jackson `2.12.2` (and legacy Codehaus `jackson-core-asl:1.9.12`) remain via `com.datastax.oss:java-driver-core:4.13.0`. Per policy these are addressed separately by **upgrading or replacing the Cassandra driver** (a tradeoff to be proposed and reviewed), not by blanket Maven exclusions. This also makes the open Dependabot `jackson-databind` 2.22.0 bump obsolete.

## Verification

- `mvn dependency:tree`: no direct `com.fasterxml.jackson`; `gson:2.10.1` present; remaining Jackson is transitive via the Cassandra driver only.
- `XRCSVEncoder` confirmed the only project code that used the Jackson API.
- Full `mvn test` suite passes (unit + Turtle integration).

Design spec and implementation plan included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)